### PR TITLE
feat(smitten): memoize creation of new emitters

### DIFF
--- a/bm/bm.createWide.ts
+++ b/bm/bm.createWide.ts
@@ -1,0 +1,23 @@
+/**
+ * Created by tushar on 15/01/17.
+ */
+import * as Benchmark from 'benchmark'
+import {create} from '../modules/smitten/index'
+
+let suite = new Benchmark.Suite()
+
+function pass() {}
+suite
+  .add('create-1e3-times', function() {
+    let root = create(pass)
+    let e = root
+    for (let i = 0; i < 1e3; ++i) {
+      e = root.of(i.toString())
+    }
+    e.emit(0)
+  })
+
+  .on('cycle', function(event: any) {
+    console.log(String(event.target)) // tslint:disable-line
+  })
+  .run()

--- a/modules/smitten/index.ts
+++ b/modules/smitten/index.ts
@@ -29,13 +29,11 @@ class DefaultEmitter implements Smitten {
   }
 
   of(type: string | number): Smitten {
-    if (this.cache.hasOwnProperty(type)) {
-      return this.cache[type]
+    if (!this.cache.hasOwnProperty(type)) {
+      this.cache[type] = new DefaultEmitter(type, this)
     }
 
-    const newEmitter = new DefaultEmitter(type, this)
-    this.cache[type] = newEmitter
-    return newEmitter
+    return this.cache[type]
   }
 }
 

--- a/modules/smitten/index.ts
+++ b/modules/smitten/index.ts
@@ -14,7 +14,7 @@ class DefaultEmitter implements Smitten {
     readonly type: string | number,
     readonly parent: DefaultEmitter | RootEmitter,
     private readonly cache: {
-      [key: string]: DefaultEmitter
+      [key: string]: Smitten
     } = {}
   ) {}
 
@@ -38,10 +38,19 @@ class DefaultEmitter implements Smitten {
 }
 
 class RootEmitter implements Smitten {
-  constructor(public readonly emit: (obj: any) => void) {}
+  constructor(
+    public readonly emit: (obj: any) => void,
+    private readonly cache: {
+      [key: string]: Smitten
+    } = {}
+  ) {}
 
   of(type: string | number): Smitten {
-    return new DefaultEmitter(type, this)
+    if (!this.cache.hasOwnProperty(type)) {
+      this.cache[type] = new DefaultEmitter(type, this)
+    }
+
+    return this.cache[type]
   }
 }
 

--- a/modules/smitten/index.ts
+++ b/modules/smitten/index.ts
@@ -10,16 +10,13 @@ export interface Smitten<T extends string | number = string | number> {
 }
 
 class DefaultEmitter implements Smitten {
-  private cache: {
-    [key: string]: DefaultEmitter
-  }
-
   constructor(
     readonly type: string | number,
-    readonly parent: DefaultEmitter | RootEmitter
-  ) {
-    this.cache = {}
-  }
+    readonly parent: DefaultEmitter | RootEmitter,
+    private readonly cache: {
+      [key: string]: DefaultEmitter
+    } = {}
+  ) {}
 
   emit = (value: any) => {
     let node: DefaultEmitter | RootEmitter = this

--- a/modules/smitten/index.ts
+++ b/modules/smitten/index.ts
@@ -10,10 +10,16 @@ export interface Smitten<T extends string | number = string | number> {
 }
 
 class DefaultEmitter implements Smitten {
+  private cache: {
+    [key: string]: DefaultEmitter
+  }
+
   constructor(
     readonly type: string | number,
     readonly parent: DefaultEmitter | RootEmitter
-  ) {}
+  ) {
+    this.cache = {}
+  }
 
   emit = (value: any) => {
     let node: DefaultEmitter | RootEmitter = this
@@ -24,8 +30,15 @@ class DefaultEmitter implements Smitten {
     }
     node.emit(act)
   }
+
   of(type: string | number): Smitten {
-    return new DefaultEmitter(type, this)
+    if (this.cache.hasOwnProperty(type)) {
+      return this.cache[type]
+    }
+
+    const newEmitter = new DefaultEmitter(type, this)
+    this.cache[type] = newEmitter
+    return newEmitter
   }
 }
 

--- a/test/smitten/smitten.ts
+++ b/test/smitten/smitten.ts
@@ -66,6 +66,6 @@ describe('hoe', () => {
     const e = root.of('1st_child')
     const f = e.of('2nd_child')
     const g = e.of('2nd_child')
-    assert.deepStrictEqual(f, g)
+    assert.strictEqual(f, g)
   })
 })

--- a/test/smitten/smitten.ts
+++ b/test/smitten/smitten.ts
@@ -41,7 +41,6 @@ describe('hoe', () => {
       action('A', action('B', 200))
     ])
   })
-
   it('should persist arguments', () => {
     const {actions, listener} = testListener()
     const e = create(listener)
@@ -59,5 +58,14 @@ describe('hoe', () => {
       }
       e.emit(null)
     })
+  })
+  it('should memoize `e.of`', () => {
+    const {listener} = testListener()
+    const root = create(listener)
+    /* create emitter tree */
+    const e = root.of('1st_child')
+    const f = e.of('2nd_child')
+    const g = e.of('2nd_child')
+    assert.deepStrictEqual(f, g)
   })
 })


### PR DESCRIPTION
Memoization of emitter will give a significant performance boost while using them inside view functions.

**Changes**
- [x] Enable caching of emitter.
- [ ] Add benchmarks.
- [ ] Make caching optional using a configuration
