### PR TITLE
Feat: Implement `bindTo` method for Smitten

### DIFF
--- a/modules/smitten/index.ts
+++ b/modules/smitten/index.ts
@@ -6,7 +6,7 @@ import {action} from '@action-land/core'
 
 export interface Smitten<T extends string | number = string | number> {
   of<S extends string | number>(type: T): Smitten<S>
-  emit(obj: any): void
+  emit(value: any): void
   bindTo<S extends string | number>(value: any): Smitten<S>
 }
 

--- a/modules/smitten/index.ts
+++ b/modules/smitten/index.ts
@@ -7,23 +7,34 @@ import {action} from '@action-land/core'
 export interface Smitten<T extends string | number = string | number> {
   of<S extends string | number>(type: T): Smitten<S>
   emit(obj: any): void
+  bindTo<S extends string | number>(value: any): Smitten<S>
 }
 
 class DefaultEmitter implements Smitten {
+  private returnValue: any
+
   constructor(
     readonly type: string | number,
     readonly parent: DefaultEmitter | RootEmitter
-  ) {}
+  ) {
+    this.returnValue = null
+  }
+
+  bindTo<S extends string | number>(value: any): Smitten<S> {
+    this.returnValue = value
+    return this
+  }
 
   emit = (value: any) => {
     let node: DefaultEmitter | RootEmitter = this
-    let act = value
+    let act = this.returnValue === null ? value : this.returnValue
     while (node instanceof DefaultEmitter) {
       act = action(node.type, act)
       node = node.parent
     }
     node.emit(act)
   }
+
   of(type: string | number): Smitten {
     return new DefaultEmitter(type, this)
   }
@@ -31,6 +42,10 @@ class DefaultEmitter implements Smitten {
 
 class RootEmitter implements Smitten {
   constructor(public readonly emit: (obj: any) => void) {}
+
+  bindTo<S extends string | number>(value: any): Smitten<S> {
+    return this
+  }
 
   of(type: string | number): Smitten {
     return new DefaultEmitter(type, this)

--- a/test/smitten/smitten.ts
+++ b/test/smitten/smitten.ts
@@ -60,4 +60,19 @@ describe('hoe', () => {
       e.emit(null)
     })
   })
+  describe('bindTo', () => {
+    it('should emit with arguments', () => {
+      const {actions, listener} = testListener()
+      const e = create(listener)
+      const f = e.of('A').bindTo(100)
+      f.emit(200)
+      assert.equal(actions[0].value, 100)
+    })
+    it('should not bind a value on root emitter', () => {
+      const {actions, listener} = testListener()
+      const e = create(listener).bindTo(100)
+      e.emit.call(null, 200)
+      assert.notStrictEqual(actions, [200])
+    })
+  })
 })


### PR DESCRIPTION
## Changes

- Earlier, if you wanted to always emit an action with a particular value you had to do something like
```
e.of('sampleType').bind(null, 'sampleValue')
```
- Now you can just do the following:
```
e.of('sampleType').bindTo('sampleValue')
```
- and you don't get a whole other function emitting your values, it's handled natively by the Emitter class itself.

Closes #13 