### PR TITLE
Release 4.3

### DIFF
--- a/modules/component/index.ts
+++ b/modules/component/index.ts
@@ -1,3 +1,3 @@
 export {AutoForward} from './src/autoForward'
 export {Component, COM} from './src/component'
-export {ComponentNext} from './src/componentNext'
+export {ComponentNext, ComponentProps} from './src/componentNext'

--- a/modules/component/internals/linkedList.ts
+++ b/modules/component/internals/linkedList.ts
@@ -1,31 +1,44 @@
-interface INode<T> {
-  value: T
-  next: INode<T> | null
+export abstract class LinkedList<A> {
+  abstract readonly head: A
+  abstract readonly tail: LinkedList<A>
+
+  abstract isEmpty: boolean
+  prepend(element: A): LinkedList<A> {
+    return new Cons(element, this)
+  }
+
+  static get empty(): LinkedList<never> {
+    return new Empty()
+  }
+
+  static of<T>(element: T): LinkedList<T> {
+    return new Cons<T>(element, LinkedList.empty)
+  }
+
+  reduce<B>(seed: B, fn: (a: A, b: B) => B): B {
+    let n: LinkedList<A> = this
+    let r = seed
+    while (!n.isEmpty) {
+      r = fn(n.head, r)
+      n = n.tail
+    }
+    return r
+  }
 }
 
-export class LinkedList<T> {
-  private head: INode<T> | null = null
+class Empty extends LinkedList<never> {
+  isEmpty = true
+  get head(): never {
+    throw new Error('Head of empty list')
+  }
+  get tail(): never {
+    throw new Error('Tail of empty list')
+  }
+}
 
-  private createNode(value: T): INode<T> {
-    return {value, next: null}
-  }
-  private insertInFront(value: T): void {
-    const node = this.createNode(value)
-    node.next = this.head
-    this.head = node
-  }
-  public concat(value: T | T[]): LinkedList<T> {
-    if (!(value instanceof Array)) {
-      this.insertInFront(value)
-    }
-    if (value instanceof Array) {
-      value.forEach((val: T) => {
-        this.insertInFront(val)
-      })
-    }
-    return this
-  }
-  public getHead(): INode<T> | null {
-    return this.head
+class Cons<A> extends LinkedList<A> {
+  isEmpty = false
+  constructor(readonly head: A, readonly tail: LinkedList<A>) {
+    super()
   }
 }

--- a/modules/component/internals/linkedList.ts
+++ b/modules/component/internals/linkedList.ts
@@ -1,0 +1,23 @@
+interface INode<T> {
+    value: T
+    next: INode<T> | null
+}
+
+export class LinkedList<T> {
+    private head: INode<T>| null = null
+
+    private createNode (value: T): INode<T> {
+        return { value, next: null }
+    }
+
+    public concat (value: T): LinkedList<T> {
+        const node = this.createNode(value)
+        node.next = this.head
+        this.head = node
+        return this
+    }
+    public getHead  (): INode<T>| null {
+        return this.head
+    }
+
+}

--- a/modules/component/internals/linkedList.ts
+++ b/modules/component/internals/linkedList.ts
@@ -1,23 +1,31 @@
 interface INode<T> {
-    value: T
-    next: INode<T> | null
+  value: T
+  next: INode<T> | null
 }
 
 export class LinkedList<T> {
-    private head: INode<T>| null = null
+  private head: INode<T> | null = null
 
-    private createNode (value: T): INode<T> {
-        return { value, next: null }
+  private createNode(value: T): INode<T> {
+    return {value, next: null}
+  }
+  private insertInFront(value: T): void {
+    const node = this.createNode(value)
+    node.next = this.head
+    this.head = node
+  }
+  public concat(value: T | T[]): LinkedList<T> {
+    if (!(value instanceof Array)) {
+      this.insertInFront(value)
     }
-
-    public concat (value: T): LinkedList<T> {
-        const node = this.createNode(value)
-        node.next = this.head
-        this.head = node
-        return this
+    if (value instanceof Array) {
+      value.forEach((val: T) => {
+        this.insertInFront(val)
+      })
     }
-    public getHead  (): INode<T>| null {
-        return this.head
-    }
-
+    return this
+  }
+  public getHead(): INode<T> | null {
+    return this.head
+  }
 }

--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -37,6 +37,7 @@ type iProps<P> = PPP<P, 'iProps'>
 type LActionTypes<A> = A extends Action<any, infer T> ? T : never
 type LActionValues<A> = A extends Action<infer V, any> ? V : never
 type LObjectValues<O> = O extends {[k: string]: infer S} ? S : unknown
+type LActionValueForType<A, T> = A extends Action<infer V, T> ? V : never
 //#endregion
 
 /**
@@ -223,7 +224,7 @@ export class ComponentNext<P1 extends ComponentProps> {
       env: {
         actions: {
           [k in LActionTypes<iActions<P1>>]: (
-            e: iActions<P1> extends Action<infer V, k> ? V : never
+            e: LActionValueForType<iActions<P1>, k>
           ) => unknown
         }
         state: oState<P1>

--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -11,6 +11,7 @@ export type ComponentProps = {
   readonly iProps?: unknown
 }
 
+//#region TypeLambdas
 /**
  * Extracts values of the provided keys
  */
@@ -33,7 +34,6 @@ type oView<P> = PPP<P, 'oView'>
 type iChildren<P> = PPP<P, 'iChildren'>
 type iProps<P> = PPP<P, 'iProps'>
 
-//#region TypeLambdas
 type LActionTypes<A> = A extends Action<any, infer T> ? T : never
 type LActionValues<A> = A extends Action<infer V, any> ? V : never
 type LObjectValues<O> = O extends {[k: string]: infer S} ? S : unknown

--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -1,15 +1,43 @@
 import {Action, isAction, List, Nil} from '@action-land/core'
 
+export type ComponentProps = {
+  readonly iState?: unknown
+  readonly oState?: unknown
+  readonly iActions?: Action<unknown>
+  readonly oActions?: Action<unknown>
+}
+
+type PP<
+  O extends ComponentProps,
+  K extends keyof ComponentProps
+> = K extends keyof O ? O[K] : never
+
+type iState<P> = PP<P, 'iState'>
+type oState<P> = PP<P, 'oState'>
+type iActions<P> = PP<P, 'iActions'>
+type oActions<P> = PP<P, 'oActions'>
+
+//#region TypeLambdas
+type LActionTypes<A> = A extends Action<any, infer T> ? T : never
+type LActionValues<A> = A extends Action<infer V, any> ? V : never
+//#endregion
+
+/**
+ * Overwrite the props in T with props in S.
+ */
+export type iSet<T, S> = Omit<T, keyof S> & S
+
+/**
+ * Creates a new component-type with the overridden props
+ */
+export type iComponentNext<P, S> = ComponentNext<iSet<P, S>>
+
 /**
  * Removes duplicate A | A insertions.
  */
-type U<A, B> = A | B extends A & B ? A : A | B
-export class ComponentNext<
-  iState1 = unknown,
-  oState1 = unknown,
-  iActions1 = never,
-  oActions1 = never
-> {
+export type U<A, B> = A | B extends A & B ? A : A | B
+
+export class ComponentNext<P1 extends ComponentProps> {
   private constructor(
     readonly _init: (...t: unknown[]) => unknown,
     readonly _update: (a: Action<unknown>, b: unknown) => unknown = (
@@ -19,32 +47,32 @@ export class ComponentNext<
     readonly _command: (a: Action<unknown>, b: unknown) => unknown = Nil
   ) {}
 
-  lift<C extends ComponentNext>(
-    fn: (c: ComponentNext<iState1, oState1, iActions1, oActions1>) => C
-  ): C {
+  lift<P2>(fn: (c: ComponentNext<P1>) => ComponentNext<P2>): ComponentNext<P2> {
     return fn(this)
   }
 
-  static lift<S>(state: S): ComponentNext<S, S, never, never> {
+  static lift<S>(state: S): ComponentNext<{iState: S; oState: S}> {
     return new ComponentNext(() => state)
   }
 
-  matchR<T extends string | number, V, oState2 extends oState1>(
+  matchR<T extends string | number, V, oState2 extends oState<P1>>(
     type: T,
-    cb: (value: V, state: iState1) => oState2
-  ): ComponentNext<
-    iState1,
-    // oState1 | oState2 extends oState2 ? oState2 : oState1 | oState2,
-    U<oState1, oState2>,
-    iActions1 | Action<V, T>,
-    oActions1
+    cb: (value: V, state: iState<P1>) => oState2
+  ): iComponentNext<
+    P1,
+    {
+      iActions: T extends LActionTypes<iActions<P1>>
+        ? Action<V & LActionValues<iActions<P1>>, T>
+        : Action<V, T> | iActions<P1>
+      oState: oState2 | iState<P1>
+    }
   > {
     return new ComponentNext(
       this._init,
       (a, s) => {
         const s2 = this._update(a, s)
         if (isAction(a) && a.type === type) {
-          return cb(a.value, s2 as iState1)
+          return cb(a.value, s2 as iState<P1>)
         }
         return s2
       },
@@ -54,12 +82,12 @@ export class ComponentNext<
 
   matchC<T extends string | number, V, V2, T2 extends string | number>(
     type: T,
-    cb: (value: V, state: iState1) => Action<V2, T2>
-  ): ComponentNext<iState1, oState1, iActions1, oActions1 | Action<V2, T2>> {
+    cb: (value: V, state: iState<P1>) => Action<V2, T2>
+  ): iComponentNext<P1, {oActions: oActions<P1> | Action<V2, T2>}> {
     return new ComponentNext(this._init, this._update, (a, s) => {
       const a2 = this._command(a, s) as Action<unknown>
       if (isAction(a) && a.type === type) {
-        return List(a2, cb(a.value, s as iState1))
+        return List(a2, cb(a.value, s as iState<P1>))
       }
       return a2
     })

--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -71,7 +71,14 @@ export class ComponentNext<P1 extends ComponentProps> {
 
   static lift<S>(state: S): ComponentNext<{iState: S; oState: S; oView: void}> {
     const i = () => state
-    return new ComponentNext(i, arg2, Nil, () => undefined, {}, new LinkedList())
+    return new ComponentNext(
+      i,
+      arg2,
+      Nil,
+      () => undefined,
+      {},
+      new LinkedList()
+    )
   }
 
   matchR<T extends string | number, V, oState2 extends oState<P1>>(
@@ -207,7 +214,7 @@ export class ComponentNext<P1 extends ComponentProps> {
       },
       this._view,
       spec,
-      this._iActions
+      this._iActions.concat(Object.keys(spec))
     )
   }
 

--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -128,7 +128,7 @@ export class ComponentNext<P1 extends ComponentProps> {
       (a, s) => {
         const a2 = this._command(a, s) as Action<unknown>
         if (isAction(a) && a.type === type) {
-          return List(a2, cb(a.value, s as iState<P1>))
+          return List(a2, cb(a.value as any, s as iState<P1>))
         }
         return a2
       },

--- a/modules/core/src/action.ts
+++ b/modules/core/src/action.ts
@@ -7,9 +7,9 @@ type AType = string | number
  * Interface for Action
  * @interface
  */
-export interface Action<V, T extends AType = AType> {
-  type: T
-  value: V
+export interface Action<V, T = AType> {
+  readonly type: T
+  readonly value: V
 }
 
 function createAction<T extends AType, V>(type: T, value: V) {

--- a/modules/core/src/isAction.ts
+++ b/modules/core/src/isAction.ts
@@ -1,17 +1,22 @@
 import {Action} from './action'
 
+const hasOwnProperty = <K extends string | number>(
+  o: unknown,
+  k: K
+): o is {[k in K]: unknown} => {
+  return typeof o === 'object' && o !== null && o.hasOwnProperty(k)
+}
+
 /**
  * Checks if the object is of Action type
  * @function
  * @param {any} obj
  * @returns {boolean}
  */
-export function isAction(obj: any): obj is Action<any> {
+export function isAction(obj: unknown): obj is Action<unknown> {
   return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    obj.hasOwnProperty('type') &&
-    obj.hasOwnProperty('value') &&
+    hasOwnProperty(obj, 'type') &&
+    hasOwnProperty(obj, 'value') &&
     (typeof obj.type === 'string' || typeof obj.type === 'number')
   )
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ts-curry": "^1.0.4",
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
-    "typedoc": "^0.14.2",
+    "@tusharmathur/typedoc": "^1.0.0",
     "typescript": "^3.5.2",
     "typings-checker": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "url": "https://github.com/action-land/action-land.git"
   },
   "devDependencies": {
+    "@tusharmathur/typedoc": "^1.0.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.0.10",
-    "@types/ramda": "^0.26.12",
+    "@types/node": "^12.6.2",
+    "@types/ramda": "^0.26.15",
     "benchmark": "^2.1.4",
     "cz-lerna-changelog": "^2.0.2",
     "lerna": "^3.15.0",
@@ -32,8 +33,7 @@
     "ts-curry": "^1.0.4",
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
-    "@tusharmathur/typedoc": "^1.0.0",
-    "typescript": "^3.5.2",
+    "typescript": "^3.5.3",
     "typings-checker": "^2.0.0"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "mocha --require=ts-node/register --watch-extensions ts test/**/*.ts",
+    "test": "mocha test/**/*.ts",
     "check-types": "typings-checker typings/type.ts",
     "prettier": "git ls-files | grep '.ts$' | xargs prettier --write --config=.prettierrc",
     "lint": "tslint --project .",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "mocha test/**/*.ts",
     "check-types": "typings-checker typings/type.ts",
-    "prettier": "git ls-files | grep '.ts$' | xargs prettier --write --config=.prettierrc",
+    "prettier": "git ls-files | grep '\\.ts$' | xargs prettier --write --config=.prettierrc",
     "lint": "tslint --project .",
     "preversion": "tsc -d",
     "lerna-publish": "lerna publish --conventional-commits",

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -12,12 +12,12 @@ describe('ComponentNext', () => {
   })
 
   describe('update', () => {
-    it('should update on the passed state', () => {
+    it('should not update the current state', () => {
       const actual = ComponentNext.lift({count: 0})._update(
         action('inc', null),
-        {node: {count: 10, color: 'red'}, children: {}}
+        {count: 10}
       )
-      const expected = {node: {count: 10, color: 'red'}, children: {}}
+      const expected = {count: 10}
 
       assert.deepStrictEqual(actual, expected)
     })

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -174,23 +174,6 @@ describe('ComponentNext', () => {
       const expected = List(action('X', 'X'), action('X', action('Y', 'Y')))
       assert.deepStrictEqual(actual, expected)
     })
-
-    it('should concat child name as action types in iActions', () => {
-      const component = ComponentNext.lift(0)
-        .matchC('X', () => action('X', 'X'))
-        .install({
-          Z: ComponentNext.lift(1).matchC('Y', (e, s) => action('Y', 'Y'))
-        })
-      const actual = component._iActions.getHead()
-      const expected = {
-        value: 'Z',
-        next: {
-          value: 'X',
-          next: null
-        }
-      }
-      assert.deepEqual(actual, expected)
-    })
   })
 
   describe('render', () => {

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -1,7 +1,7 @@
+import {ComponentNext} from '@action-land/component'
 import {action, Action} from '@action-land/core'
 import {create} from '@action-land/smitten'
 import * as assert from 'assert'
-import {ComponentNext} from '../../modules/component/src/componentNext'
 
 describe('ComponentNext', () => {
   describe('lift', () => {

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -1,4 +1,5 @@
-import {action} from '@action-land/core'
+import {action, Action} from '@action-land/core'
+import {create} from '@action-land/smitten'
 import * as assert from 'assert'
 import {ComponentNext} from '../../modules/component/src/componentNext'
 
@@ -8,13 +9,15 @@ describe('ComponentNext', () => {
       const component = ComponentNext.lift({count: 0})
       assert.ok(component instanceof ComponentNext)
     })
+  })
 
+  describe('update', () => {
     it('should update on the passed state', () => {
       const actual = ComponentNext.lift({count: 0})._update(
         action('inc', null),
-        {count: 10, color: 'red'}
+        {node: {count: 10, color: 'red'}, children: {}}
       )
-      const expected = {count: 10, color: 'red'}
+      const expected = {node: {count: 10, color: 'red'}, children: {}}
 
       assert.deepStrictEqual(actual, expected)
     })
@@ -23,10 +26,8 @@ describe('ComponentNext', () => {
   describe('init', () => {
     it('should return the initial state', () => {
       const component = ComponentNext.lift({count: 0})
-        .matchR('inc', (e, s) => ({count: s.count + 1, lastAction: 'inc'}))
-        .matchR('dec', (e, s) => ({count: s.count - 1, lastAction: 'dec'}))
       const actual = component._init()
-      const expected = {count: 0}
+      const expected = {node: {count: 0}, children: {}}
       assert.deepEqual(actual, expected)
     })
   })
@@ -38,7 +39,7 @@ describe('ComponentNext', () => {
         .matchR('dec', (e, s) => ({count: s.count - 1, lastAction: 'dec'}))
 
       const actual = component._update(action('inc', null), component._init())
-      const expected = {count: 1, lastAction: 'inc'}
+      const expected = {node: {count: 1, lastAction: 'inc'}, children: {}}
 
       assert.deepEqual(actual, expected)
     })
@@ -49,11 +50,15 @@ describe('ComponentNext', () => {
         (e, s) => ({count: s.count + 1})
       )
 
+      const iState: any = component._init()
       const actual = component._update(action('inc', null), {
-        ...component._init(),
-        color: 'red'
+        node: {
+          ...iState.node,
+          color: 'red'
+        },
+        children: {}
       })
-      const expected = {count: 1, color: 'red'}
+      const expected = {node: {count: 1, color: 'red'}, children: {}}
 
       assert.deepEqual(actual, expected)
     })
@@ -65,7 +70,10 @@ describe('ComponentNext', () => {
         childB: ComponentNext.lift({countB: 100})
       })
       const actual = component._init()
-      const expected = {node: {countA: 0}, children: {childB: {countB: 100}}}
+      const expected = {
+        node: {countA: 0},
+        children: {childB: {node: {countB: 100}, children: {}}}
+      }
 
       assert.deepEqual(actual, expected)
     })
@@ -81,7 +89,10 @@ describe('ComponentNext', () => {
         action('childB', action('inc', null)),
         component._init()
       )
-      const expected = {node: {countA: 0}, children: {childB: {countB: 101}}}
+      const expected = {
+        node: {countA: 0},
+        children: {childB: {node: {countB: 101}, children: {}}}
+      }
 
       assert.deepEqual(actual, expected)
     })
@@ -98,9 +109,83 @@ describe('ComponentNext', () => {
         })
 
       const actual = component._update(action('inc', null), component._init())
-      const expected = {node: {a: 1}, children: {child: {b: 100}}}
+      const expected = {
+        node: {a: 1},
+        children: {child: {node: {b: 100}, children: {}}}
+      }
 
       assert.deepStrictEqual(actual, expected)
+    })
+  })
+
+  describe('render', () => {
+    it('should create vNodes', () => {
+      const component = ComponentNext.lift(10).render(_ => [
+        'Hello',
+        _.state + 1
+      ])
+      const actual = component._view({}, component._init(), {})
+      const expected = ['Hello', 11]
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    it('should create children views', () => {
+      const component = ComponentNext.lift('Hello')
+        .forward({child: ComponentNext.lift('World').render(_ => _.state)})
+        .render(_ => [_.state, _.children.child()])
+
+      const actual = component._view(create(() => {}), component._init(), {})
+      const expected = ['Hello', 'World']
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    it('should render with props', () => {
+      const component = ComponentNext.lift('Hello')
+        .forward({
+          child: ComponentNext.lift('World').render((_, p: string) => p)
+        })
+        .render((_, p: string) => [p, _.children.child('World')])
+
+      const actual = component._view(
+        create(() => {}),
+        component._init(),
+        'Hello'
+      )
+      const expected = ['Hello', 'World']
+
+      assert.deepStrictEqual(actual, expected)
+    })
+
+    it('should emit actions', () => {
+      const result: Action<unknown>[] = []
+      const e = create(a => result.push(a))
+      const component = ComponentNext.lift(10)
+        .matchR('add', (a: number, s) => s + a)
+        .render(_ => _.actions.add(100))
+
+      component._view(e, component._init(), '')
+      const expected = [action('add', 100)]
+
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('should pass on the emitter', () => {
+      const result: Action<unknown>[] = []
+      const e = create(a => result.push(a))
+      const component = ComponentNext.lift(10)
+        .forward({
+          child: ComponentNext.lift(0)
+            .matchR('add', (a: number, s) => s + a)
+            .render(_ => _.actions.add(100))
+        })
+        .render(_ => _.children.child())
+
+      component._view(e, component._init(), '')
+      const expected = [action('child', action('add', 100))]
+
+      assert.deepStrictEqual(result, expected)
     })
   })
 })

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -174,6 +174,23 @@ describe('ComponentNext', () => {
       const expected = List(action('X', 'X'), action('X', action('Y', 'Y')))
       assert.deepStrictEqual(actual, expected)
     })
+
+    it('should concat child name as action types in iActions', () => {
+      const component = ComponentNext.lift(0)
+        .matchC('X', () => action('X', 'X'))
+        .install({
+          Z: ComponentNext.lift(1).matchC('Y', (e, s) => action('Y', 'Y'))
+        })
+      const actual = component._iActions.getHead()
+      const expected = {
+        value: 'Z',
+        next: {
+          value: 'X',
+          next: null
+        }
+      }
+      assert.deepEqual(actual, expected)
+    })
   })
 
   describe('render', () => {

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -8,6 +8,16 @@ describe('ComponentNext', () => {
       const component = ComponentNext.lift({count: 0})
       assert.ok(component instanceof ComponentNext)
     })
+
+    it('should update on the passed state', () => {
+      const actual = ComponentNext.lift({count: 0})._update(
+        action('inc', null),
+        {count: 10, color: 'red'}
+      )
+      const expected = {count: 10, color: 'red'}
+
+      assert.deepStrictEqual(actual, expected)
+    })
   })
 
   describe('init', () => {
@@ -31,6 +41,66 @@ describe('ComponentNext', () => {
       const expected = {count: 1, lastAction: 'inc'}
 
       assert.deepEqual(actual, expected)
+    })
+
+    it('should merge with the initial state', () => {
+      const component = ComponentNext.lift({count: 0}).matchR(
+        'inc',
+        (e, s) => ({count: s.count + 1})
+      )
+
+      const actual = component._update(action('inc', null), {
+        ...component._init(),
+        color: 'red'
+      })
+      const expected = {count: 1, color: 'red'}
+
+      assert.deepEqual(actual, expected)
+    })
+  })
+
+  describe('forward', () => {
+    it('should perform nested initialization', () => {
+      const component = ComponentNext.lift({countA: 0}).forward({
+        childB: ComponentNext.lift({countB: 100})
+      })
+      const actual = component._init()
+      const expected = {node: {countA: 0}, children: {childB: {countB: 100}}}
+
+      assert.deepEqual(actual, expected)
+    })
+
+    it('should forward actions', () => {
+      const component = ComponentNext.lift({countA: 0}).forward({
+        childB: ComponentNext.lift({countB: 100}).matchR('inc', (e, s) => ({
+          ...s,
+          countB: s.countB + 1
+        }))
+      })
+      const actual = component._update(
+        action('childB', action('inc', null)),
+        component._init()
+      )
+      const expected = {node: {countA: 0}, children: {childB: {countB: 101}}}
+
+      assert.deepEqual(actual, expected)
+    })
+
+    it('should not forward if the action does not match', () => {
+      const component = ComponentNext.lift({a: 0})
+        .matchR('inc', (e, s) => ({
+          a: s.a + 1
+        }))
+        .forward({
+          child: ComponentNext.lift({b: 100}).matchR('inc', (e, s) => ({
+            b: s.b + 1
+          }))
+        })
+
+      const actual = component._update(action('inc', null), component._init())
+      const expected = {node: {a: 1}, children: {child: {b: 100}}}
+
+      assert.deepStrictEqual(actual, expected)
     })
   })
 })

--- a/test/component/linkedList.ts
+++ b/test/component/linkedList.ts
@@ -1,25 +1,37 @@
-import { LinkedList } from '@action-land/component/internals/linkedList'
+import {LinkedList} from '@action-land/component/internals/linkedList'
 import * as assert from 'assert'
 describe('linked list', () => {
-    it('should create a linked list with single node', () => {
-        const l1 = new LinkedList().concat('10')
-        const actual = l1.getHead()
-        const expected = {
-            value: '10',
-            next: null
-        }
-        assert.deepStrictEqual(actual, expected)
-    })
-    it('should concat passed value in front of the linked list', () => {
-        const l1 = new LinkedList().concat('10').concat('12')
-        const actual = l1.getHead()
-        const expected = {
-            value: '12',
-            next: {
-                value: '10',
-                next: null
-            }
-        }
-        assert.deepStrictEqual(actual, expected)
-    })
+  it('should create a linked list with single node', () => {
+    const l1 = new LinkedList().concat('10')
+    const actual = l1.getHead()
+    const expected = {
+      value: '10',
+      next: null
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+  it('should concat passed value in front of the linked list', () => {
+    const l1 = new LinkedList().concat('10').concat('12')
+    const actual = l1.getHead()
+    const expected = {
+      value: '12',
+      next: {
+        value: '10',
+        next: null
+      }
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+  it('should concat passed value in front of the linked list', () => {
+    const l1 = new LinkedList().concat(['10', '12'])
+    const actual = l1.getHead()
+    const expected = {
+      value: '12',
+      next: {
+        value: '10',
+        next: null
+      }
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
 })

--- a/test/component/linkedList.ts
+++ b/test/component/linkedList.ts
@@ -1,37 +1,14 @@
 import {LinkedList} from '@action-land/component/internals/linkedList'
 import * as assert from 'assert'
+
 describe('linked list', () => {
   it('should create a linked list with single node', () => {
-    const l1 = new LinkedList().concat('10')
-    const actual = l1.getHead()
-    const expected = {
-      value: '10',
-      next: null
-    }
-    assert.deepStrictEqual(actual, expected)
+    const l = LinkedList.of(10)
+    assert.ok(l instanceof LinkedList)
   })
-  it('should concat passed value in front of the linked list', () => {
-    const l1 = new LinkedList().concat('10').concat('12')
-    const actual = l1.getHead()
-    const expected = {
-      value: '12',
-      next: {
-        value: '10',
-        next: null
-      }
-    }
-    assert.deepStrictEqual(actual, expected)
-  })
-  it('should concat passed value in front of the linked list', () => {
-    const l1 = new LinkedList().concat(['10', '12'])
-    const actual = l1.getHead()
-    const expected = {
-      value: '12',
-      next: {
-        value: '10',
-        next: null
-      }
-    }
-    assert.deepStrictEqual(actual, expected)
+  it('should prepend and create a new list', () => {
+    const l = LinkedList.of(10).prepend(20)
+    const r = l.reduce(0, (a, b) => a + b)
+    assert.strictEqual(r, 30)
   })
 })

--- a/test/component/linkedList.ts
+++ b/test/component/linkedList.ts
@@ -1,0 +1,25 @@
+import { LinkedList } from '@action-land/component/internals/linkedList'
+import * as assert from 'assert'
+describe('linked list', () => {
+    it('should create a linked list with single node', () => {
+        const l1 = new LinkedList().concat('10')
+        const actual = l1.getHead()
+        const expected = {
+            value: '10',
+            next: null
+        }
+        assert.deepStrictEqual(actual, expected)
+    })
+    it('should concat passed value in front of the linked list', () => {
+        const l1 = new LinkedList().concat('10').concat('12')
+        const actual = l1.getHead()
+        const expected = {
+            value: '12',
+            next: {
+                value: '10',
+                next: null
+            }
+        }
+        assert.deepStrictEqual(actual, expected)
+    })
+})

--- a/test/core/action.ts
+++ b/test/core/action.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert'
-import {describe, it} from 'mocha'
 import {action, isNil, Nil} from '../../modules/core/index'
 
 describe('action', () => {

--- a/test/core/isAction.ts
+++ b/test/core/isAction.ts
@@ -3,7 +3,6 @@
  */
 
 import * as assert from 'assert'
-import {describe, it} from 'mocha'
 import {action, isAction} from '../../modules/core/index'
 
 describe('isAction', () => {

--- a/test/core/list.ts
+++ b/test/core/list.ts
@@ -3,7 +3,6 @@
  */
 
 import * as assert from 'assert'
-import {describe, it} from 'mocha'
 import {action, isList, isNil, List, Nil} from '../../modules/core/index'
 
 describe('List', () => {

--- a/test/match/match.ts
+++ b/test/match/match.ts
@@ -1,6 +1,5 @@
 import {action} from '@action-land/core'
 import * as assert from 'assert'
-import {describe, it} from 'mocha'
 import {match} from '../../modules/match/index'
 
 describe('match', () => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--require=ts-node/register
+--watch-extensions ts

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -121,3 +121,11 @@ $(
     })
     .render((_, p: boolean) => _.children)
 ).oView
+
+// $ExpectType (e: string) => unknown
+$(
+  ComponentNext.lift(0)
+    .matchR('inc', (e: string, s) => s)
+    .matchR('dec', (e: number, s) => s)
+    .render((_, p: boolean) => _.actions.inc)
+).oView

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -35,3 +35,40 @@ $(
     .matchC('inc', (e, s) => action('HTTP', {url: 'abc.com'}))
     .matchC('dec', (e, s) => action('Write', {data: 'abc'}))
 ).oActions
+
+// $ExpectType { node: { count: number; }; children: { child1: { i: boolean; }; child2: { i: string; }; }; }
+$(
+  ComponentNext.lift({count: 0}).forward({
+    child1: ComponentNext.lift({i: true}),
+    child2: ComponentNext.lift({i: 'Hi'})
+  })
+).oState
+
+// $ExpectType { node: { count: number; }; children: { child1: { i: boolean; }; child2: { i: string; }; }; }
+$(
+  ComponentNext.lift({count: 0}).forward({
+    child1: ComponentNext.lift({i: true}),
+    child2: ComponentNext.lift({i: 'Hi'})
+  })
+).iState
+
+// $ExpectType Action<unknown, "X"> | Action<Action<unknown, "A">, "childA"> | Action<Action<unknown, "B">, "childB">
+$(
+  ComponentNext.lift({count: 0})
+    .matchR('X', (e, s) => s)
+    .forward({
+      childA: ComponentNext.lift({i: true}).matchR('A', (e, s) => s),
+      childB: ComponentNext.lift({i: true}).matchR('B', (e, s) => s)
+    })
+).iActions
+
+// $ExpectType Action<null, "X"> | Action<Action<null, "A">, "childA">
+$(
+  ComponentNext.lift({count: 0})
+    .matchC('X', (e, s) => action('X', null))
+    .forward({
+      childA: ComponentNext.lift({i: true}).matchC('A', (e, s) =>
+        action('A', null)
+      )
+    })
+).oActions

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -62,6 +62,13 @@ $(
     })
 ).iActions
 
+// $ExpectType { childA: ComponentNext<{ iState: number; oState: number; oView: void; }>; }
+$(
+  ComponentNext.lift(0).forward({
+    childA: ComponentNext.lift(10)
+  })
+).iChildren
+
 // $ExpectType Action<null, "X"> | Action<Action<null, "A">, "childA">
 $(
   ComponentNext.lift({count: 0})
@@ -72,3 +79,38 @@ $(
       )
     })
 ).oActions
+
+// $ExpectType string
+$(ComponentNext.lift({count: 0}).render(() => 'Hello')).oView
+
+// $ExpectType { s: { count: number; }; p: boolean; }
+$(ComponentNext.lift({count: 0}).render((_, p: boolean) => ({s: _.state, p})))
+  .oView
+
+// $ExpectType { inc: (e: number) => unknown; }
+$(
+  ComponentNext.lift(0)
+    .matchR('inc', (e: number, s) => s + e)
+    .render((_, p: boolean) => _.actions)
+).oView
+
+// $ExpectType {}
+$(ComponentNext.lift(0).render((_, p: boolean) => _.actions)).oView
+
+// $ExpectType { childA: (p: Date) => string[]; }
+$(
+  ComponentNext.lift(0)
+    .forward({
+      childA: ComponentNext.lift(10).render((_, p: Date) => ['DONE'])
+    })
+    .render((_, p: boolean) => _.children)
+).oView
+
+// $ExpectType { childA: () => string[]; }
+$(
+  ComponentNext.lift(0)
+    .forward({
+      childA: ComponentNext.lift(10).render(() => ['DONE'])
+    })
+    .render((_, p: boolean) => _.children)
+).oView

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -1,17 +1,29 @@
-import {ComponentNext} from '@action-land/component'
-import {action} from '@action-land/core'
+import {ComponentNext, ComponentProps} from '@action-land/component'
 
-// $ExpectType ComponentNext<{ count: number; }, { count: number; }, never, never>
-ComponentNext.lift({count: 0})
+declare function $<T>(a: T): T extends ComponentNext<infer P> ? P : never
 
-// $ExpectType ComponentNext<{ count: number; }, { count: number; }, Action<unknown, "inc">, never>
-ComponentNext.lift({count: 0}).matchR('inc', (e, s) => ({count: s.count + 1}))
+// $ExpectType { count: number; }
+$(ComponentNext.lift({count: 0})).iState
 
-// $ExpectType ComponentNext<{ count: number; }, { count: number; } | { count: number; lastAction: string; }, Action<unknown, "inc">, never>
-ComponentNext.lift({count: 0}).matchR('inc', (e, s) => ({
-  count: s.count + 1,
-  lastAction: 'inc'
-}))
+// $ExpectType { count: number; }
+$(ComponentNext.lift({count: 0})).oState
 
-// $ExpectType ComponentNext<{ count: number; }, { count: number; }, never, Action<number, "GQL">>
-ComponentNext.lift({count: 0}).matchC('inc', (e, s) => action('GQL', s.count))
+// $ExpectType Action<unknown, "inc">
+$(
+  ComponentNext.lift({count: 0}).matchR('inc', (e, s) => ({count: s.count + 1}))
+).iActions
+
+// $ExpectType { count: number; } | { count: number; action: string; }
+$(
+  ComponentNext.lift({count: 0}).matchR('inc', (e, s) => ({
+    count: s.count + 1,
+    action: 'inc'
+  }))
+).oState
+
+// $ExpectType Action<{ b: number; } & { a: string; }, "inc">
+$(
+  ComponentNext.lift({count: 0})
+    .matchR('inc', (e: {a: string}, s) => s)
+    .matchR('inc', (e: {b: number}, s) => s)
+).iActions

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -1,5 +1,5 @@
 import {ComponentNext, ComponentProps} from '@action-land/component'
-import {action} from '@action-land/core'
+import {action, Nil} from '@action-land/core'
 
 declare function $<T>(a: T): T extends ComponentNext<infer P> ? P : never
 
@@ -36,9 +36,16 @@ $(
     .matchC('dec', (e, s) => action('Write', {data: 'abc'}))
 ).oActions
 
+// $ExpectType Action<{ b: number; } & { a: string; }, "inc">
+$(
+  ComponentNext.lift({count: 0})
+    .matchC('inc', (a: {a: string}, s) => Nil())
+    .matchC('inc', (a: {b: number}, s) => Nil())
+).iActions
+
 // $ExpectType { node: { count: number; }; children: { child1: { i: boolean; }; child2: { i: string; }; }; }
 $(
-  ComponentNext.lift({count: 0}).forward({
+  ComponentNext.lift({count: 0}).install({
     child1: ComponentNext.lift({i: true}),
     child2: ComponentNext.lift({i: 'Hi'})
   })
@@ -46,7 +53,7 @@ $(
 
 // $ExpectType { node: { count: number; }; children: { child1: { i: boolean; }; child2: { i: string; }; }; }
 $(
-  ComponentNext.lift({count: 0}).forward({
+  ComponentNext.lift({count: 0}).install({
     child1: ComponentNext.lift({i: true}),
     child2: ComponentNext.lift({i: 'Hi'})
   })
@@ -56,7 +63,7 @@ $(
 $(
   ComponentNext.lift({count: 0})
     .matchR('X', (e, s) => s)
-    .forward({
+    .install({
       childA: ComponentNext.lift({i: true}).matchR('A', (e, s) => s),
       childB: ComponentNext.lift({i: true}).matchR('B', (e, s) => s)
     })
@@ -64,7 +71,7 @@ $(
 
 // $ExpectType { childA: ComponentNext<{ iState: number; oState: number; oView: void; }>; }
 $(
-  ComponentNext.lift(0).forward({
+  ComponentNext.lift(0).install({
     childA: ComponentNext.lift(10)
   })
 ).iChildren
@@ -73,7 +80,7 @@ $(
 $(
   ComponentNext.lift({count: 0})
     .matchC('X', (e, s) => action('X', null))
-    .forward({
+    .install({
       childA: ComponentNext.lift({i: true}).matchC('A', (e, s) =>
         action('A', null)
       )
@@ -100,7 +107,7 @@ $(ComponentNext.lift(0).render((_, p: boolean) => _.actions)).oView
 // $ExpectType { childA: (p: Date) => string[]; }
 $(
   ComponentNext.lift(0)
-    .forward({
+    .install({
       childA: ComponentNext.lift(10).render((_, p: Date) => ['DONE'])
     })
     .render((_, p: boolean) => _.children)
@@ -109,7 +116,7 @@ $(
 // $ExpectType { childA: () => string[]; }
 $(
   ComponentNext.lift(0)
-    .forward({
+    .install({
       childA: ComponentNext.lift(10).render(() => ['DONE'])
     })
     .render((_, p: boolean) => _.children)

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -1,4 +1,5 @@
 import {ComponentNext, ComponentProps} from '@action-land/component'
+import {action} from '@action-land/core'
 
 declare function $<T>(a: T): T extends ComponentNext<infer P> ? P : never
 
@@ -27,3 +28,10 @@ $(
     .matchR('inc', (e: {a: string}, s) => s)
     .matchR('inc', (e: {b: number}, s) => s)
 ).iActions
+
+// $ExpectType Action<{ url: string; }, "HTTP"> | Action<{ data: string; }, "Write">
+$(
+  ComponentNext.lift({count: 0})
+    .matchC('inc', (e, s) => action('HTTP', {url: 'abc.com'}))
+    .matchC('dec', (e, s) => action('Write', {data: 'abc'}))
+).oActions

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -9,9 +9,11 @@ $(ComponentNext.lift({count: 0})).iState
 // $ExpectType { count: number; }
 $(ComponentNext.lift({count: 0})).oState
 
-// $ExpectType Action<unknown, "inc">
+// $ExpectType Action<number, "inc">
 $(
-  ComponentNext.lift({count: 0}).matchR('inc', (e, s) => ({count: s.count + 1}))
+  ComponentNext.lift({count: 0}).matchR('inc', (e: number, s) => ({
+    count: s.count + 1
+  }))
 ).iActions
 
 // $ExpectType { count: number; } | { count: number; action: string; }

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,15 +878,15 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/node@^12.0.10":
-  version "12.0.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
-  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
+"@types/node@^12.6.2":
+  version "12.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
+  integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
 
-"@types/ramda@^0.26.12":
-  version "0.26.12"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.12.tgz#593017c90a57c3e27a319ff0b67ee0a3ebb33f1f"
-  integrity sha512-1cIbhPNoG8VGgmwk/Izoq8iImXdM0RWuY8MFHHxSuFqxww1v+WI1kl7a0IeTUDcDjON+lqXMF1Bw+OZUss0Bqg==
+"@types/ramda@^0.26.15":
+  version "0.26.15"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.15.tgz#217d9d2133f55040bd5db0e67dbbf6ec8509446f"
+  integrity sha512-kmIO8GVOLv0A8UxFr5lJaqp4g8jbXNhH0grBaPL6NgkOqSirRKpV9+5DTmIDXTyq2G18YMdxDhnScEZtY4brtQ==
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
@@ -5082,10 +5082,15 @@ typedoc-default-themes@^0.6.0-0:
     lunr "^2.3.6"
     underscore "^1.9.1"
 
-typescript@3.5.x, typescript@^3.5.2:
+typescript@3.5.x:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+
+typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 typings-checker@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,55 +846,29 @@
     import-from "^3.0.0"
     lodash "^4.17.4"
 
+"@tusharmathur/typedoc@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tusharmathur/typedoc/-/typedoc-1.0.0.tgz#cdd02b33741c976b8dd02284b9e0a99a5a519a21"
+  integrity sha512-lgK454yVrqo+6tGAtVOkFTKZMzhFF12Mdooh6hD/gpptF63XgvVU/XriyTuLBDbk2fzB54+gZSz2U0OSF2kmvw==
+  dependencies:
+    "@types/minimatch" "3.0.3"
+    fs-extra "^7.0.1"
+    handlebars "^4.1.2"
+    highlight.js "^9.13.1"
+    lodash "^4.17.11"
+    marked "^0.6.2"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shelljs "^0.8.3"
+    typedoc-default-themes "^0.6.0-0"
+    typescript "3.5.x"
+
 "@types/benchmark@^1.0.31":
   version "1.0.31"
   resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-1.0.31.tgz#2dd3514e93396f362ba5551a7c9ff0da405c1d38"
   integrity sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA==
 
-"@types/events@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
-  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
-"@types/fs-extra@^5.0.3":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.1.0.tgz#2a325ef97901504a3828718c390d34b8426a10a1"
-  integrity sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/glob@*":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
-  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
-  dependencies:
-    "@types/events" "*"
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
-"@types/handlebars@^4.0.38":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
-  integrity sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==
-  dependencies:
-    handlebars "*"
-
-"@types/highlight.js@^9.12.3":
-  version "9.12.3"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
-  integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
-
-"@types/lodash@^4.14.110":
-  version "4.14.135"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.135.tgz#d2607c35dd68f70c2b35ba020c667493dedd8447"
-  integrity sha512-Ed+tSZ9qM1oYpi5kzdsBuOzcAIn1wDW+e8TFJ50IMJMlSopGdJgKAbhHzN6h1E1OfjlGOr2JepzEWtg9NIfoNg==
-
-"@types/marked@^0.4.0":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
-  integrity sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==
-
-"@types/minimatch@*", "@types/minimatch@3.0.3":
+"@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -904,7 +878,7 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/node@*", "@types/node@^12.0.10":
+"@types/node@^12.0.10":
   version "12.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
   integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
@@ -913,14 +887,6 @@
   version "0.26.12"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.12.tgz#593017c90a57c3e27a319ff0b67ee0a3ebb33f1f"
   integrity sha512-1cIbhPNoG8VGgmwk/Izoq8iImXdM0RWuY8MFHHxSuFqxww1v+WI1kl7a0IeTUDcDjON+lqXMF1Bw+OZUss0Bqg==
-
-"@types/shelljs@^0.8.0":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
-  integrity sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==
-  dependencies:
-    "@types/glob" "*"
-    "@types/node" "*"
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
@@ -1141,6 +1107,13 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+backbone@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
+  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
+  dependencies:
+    underscore ">=1.8.3"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2229,7 +2202,7 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -2443,7 +2416,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@*, handlebars@^4.0.6, handlebars@^4.1.0:
+handlebars@^4.1.0, handlebars@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -3011,6 +2984,11 @@ isstream@0.1.x, isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+jquery@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
+  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3219,7 +3197,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3253,6 +3231,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lunr@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.6.tgz#f278beee7ffd56ad86e6e478ce02ab2b98c78dd5"
+  integrity sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -3317,10 +3300,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
-  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
+marked@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.3.tgz#79babad78af638ba4d522a9e715cdfdd2429e946"
+  integrity sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==
 
 mem@^4.0.0:
   version "4.3.0"
@@ -4094,7 +4077,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.0:
+progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -4556,7 +4539,7 @@ shelljs@0.7.0:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.8.2:
+shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -5089,40 +5072,17 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
-  integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
-
-typedoc@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"
-  integrity sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==
+typedoc-default-themes@^0.6.0-0:
+  version "0.6.0-0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.0-0.tgz#a4867eaf91fb7888efd01680f1328b72e8a33640"
+  integrity sha512-O7hBMS1yBCozvVUntIIdlBk04WiqM+f6NOEc9p+LimJSFKJMF66cgzejeiybuTk6mgbMJW+olg42BNYC8E9x9Q==
   dependencies:
-    "@types/fs-extra" "^5.0.3"
-    "@types/handlebars" "^4.0.38"
-    "@types/highlight.js" "^9.12.3"
-    "@types/lodash" "^4.14.110"
-    "@types/marked" "^0.4.0"
-    "@types/minimatch" "3.0.3"
-    "@types/shelljs" "^0.8.0"
-    fs-extra "^7.0.0"
-    handlebars "^4.0.6"
-    highlight.js "^9.13.1"
-    lodash "^4.17.10"
-    marked "^0.4.0"
-    minimatch "^3.0.0"
-    progress "^2.0.0"
-    shelljs "^0.8.2"
-    typedoc-default-themes "^0.5.0"
-    typescript "3.2.x"
+    backbone "^1.1.2"
+    jquery "^2.2.4"
+    lunr "^2.3.6"
+    underscore "^1.9.1"
 
-typescript@3.2.x:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
-typescript@^3.5.2:
+typescript@3.5.x, typescript@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
@@ -5152,6 +5112,11 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+underscore@>=1.8.3, underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- [x] Typings for `isAction` should use `unknown` instead of `any`
- [x] `Component.forward` should take in a spec object instead of working with strings.
- [ ] Add type safety on `_update` `_init` `_command`
- [x] Add type safety for view types while composing components.
- [x] Rename all type-lambdas with a prefix `L`
- [ ] Emit Nested Actions From View directly.
- [x] Use linked lists instead of arrays for `_actions`