### PR TITLE
Tweaked 'from' method to pass old component more easily

### DIFF
--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -290,12 +290,17 @@ export class ComponentNext<P1 extends ComponentProps> {
     )
   }
 
-  static from<A, V, P>(
-    init: (...t: any[]) => A,
-    update: (a: any, s: any) => any,
-    command: (a: any, s: any) => any,
+  static from<A, V, P>({
+    init,
+    update,
+    command,
+    view
+  }: {
+    init: (...t: any[]) => A
+    update: (a: any, s: any) => any
+    command: (a: any, s: any) => any
     view: (e: any, s: any, p: P) => V
-  ): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
+  }): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
     return new ComponentNext(
       init,
       update,

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -137,14 +137,14 @@ $(
 $(ComponentNext.lift({count: 10}).configure(s => ({...s, color: 'red'}))).iState
 
 // $ExpectType ComponentNext<{ iState: number; oState: number; oView: string[]; iProps: Date; }>
-ComponentNext.from(
-  (a: string, b: number) => 10,
-  (a: Action<unknown>, b: number) => b,
-  (a: Action<unknown>, b: number) => Nil(),
-  (e: Smitten, m: number, s: Date) => {
+ComponentNext.from({
+  init: (a: string, b: number) => 10,
+  update: (a: Action<unknown>, b: number) => b,
+  command: (a: Action<unknown>, b: number) => Nil(),
+  view: (e: Smitten, m: number, s: Date) => {
     return ['Hello']
   }
-)
+})
 
 // $ExpectType ComponentNext<{ iState: undefined; oState: undefined; oView: void; }>
 ComponentNext.empty


### PR DESCRIPTION
affects: @action-land/component

BREAKING CHANGE:
Breaks "from" method in ComponentNext