### PR TITLE
refactor(component): from operator component as an object

### DIFF
--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -290,17 +290,17 @@ export class ComponentNext<P1 extends ComponentProps> {
     )
   }
 
-  static from<A, V, P>(
-    init: (...t: any[]) => A,
-    update: (a: any, s: any) => any,
-    command: (a: any, s: any) => any,
+  static from<A, V, P>(component: {
+    init: (...t: any[]) => A
+    update: (a: any, s: any) => any
+    command: (a: any, s: any) => any
     view: (e: any, s: any, p: P) => V
-  ): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
+  }): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
     return new ComponentNext(
-      init,
-      update,
-      command,
-      view as any,
+      component.init,
+      component.update,
+      component.command,
+      component.view as any,
       {},
       LinkedList.empty
     )

--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -290,14 +290,17 @@ export class ComponentNext<P1 extends ComponentProps> {
     )
   }
 
-  static from<A, V, P>(component: {
-    init: (...t: any[]) => A
-    update: (a: any, s: any) => any
-    command: (a: any, s: any) => any
-    view: (e: any, s: any, p: P) => V
-  }): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
+  static from<A, V, P, I extends unknown[]>(
+    component: {
+      init: (...t: I) => A
+      update: (a: any, s: any) => any
+      command: (a: any, s: any) => any
+      view: (e: any, s: any, p: P) => V
+    },
+    initParams: I
+  ): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
     return new ComponentNext(
-      component.init,
+      () => component.init(...initParams),
       component.update,
       component.command,
       component.view as any,

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -1,6 +1,6 @@
 import {ComponentNext} from '@action-land/component'
 import {action, Action, List, Nil} from '@action-land/core'
-import {create} from '@action-land/smitten'
+import {create, Smitten} from '@action-land/smitten'
 import * as assert from 'assert'
 
 describe('ComponentNext', () => {
@@ -291,6 +291,40 @@ describe('ComponentNext', () => {
       const actual = ComponentNext.empty._init()
       const expected = undefined
       assert.strictEqual(actual, expected)
+    })
+  })
+
+  describe('from', () => {
+    const component = ComponentNext.from(
+      {
+        init: (a: string, b: number) => 10,
+        update: (a: Action<unknown>, b: number) => 5,
+        command: (a: Action<unknown>, b: number) => action('c', 10),
+        view: (e: Smitten, m: number, s: Date) => {
+          return ['Hello']
+        }
+      },
+      ['hello', 10]
+    )
+    it('should call init of old version of component', () => {
+      const actual = component._init()
+      const expected = 10
+      assert.deepEqual(actual, expected)
+    })
+    it('should call update of old version of component', () => {
+      const actual = component._update(action('a', 10), 10)
+      const expected = 5
+      assert.deepEqual(actual, expected)
+    })
+    it('should call command of old version of component', () => {
+      const actual = component._command(action('a', 10), 10)
+      const expected = action('c', 10)
+      assert.deepEqual(actual, expected)
+    })
+    it('should call view of old version of component', () => {
+      const actual = component._view(create(() => {}), 10, new Date())
+      const expected = ['Hello']
+      assert.deepEqual(actual, expected)
     })
   })
 })

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -137,14 +137,14 @@ $(
 $(ComponentNext.lift({count: 10}).configure(s => ({...s, color: 'red'}))).iState
 
 // $ExpectType ComponentNext<{ iState: number; oState: number; oView: string[]; iProps: Date; }>
-ComponentNext.from(
-  (a: string, b: number) => 10,
-  (a: Action<unknown>, b: number) => b,
-  (a: Action<unknown>, b: number) => Nil(),
-  (e: Smitten, m: number, s: Date) => {
+ComponentNext.from({
+  init: (a: string, b: number) => 10,
+  update: (a: Action<unknown>, b: number) => b,
+  command: (a: Action<unknown>, b: number) => Nil(),
+  view: (e: Smitten, m: number, s: Date) => {
     return ['Hello']
   }
-)
+})
 
 // $ExpectType ComponentNext<{ iState: undefined; oState: undefined; oView: void; }>
 ComponentNext.empty

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -137,14 +137,17 @@ $(
 $(ComponentNext.lift({count: 10}).configure(s => ({...s, color: 'red'}))).iState
 
 // $ExpectType ComponentNext<{ iState: number; oState: number; oView: string[]; iProps: Date; }>
-ComponentNext.from({
-  init: (a: string, b: number) => 10,
-  update: (a: Action<unknown>, b: number) => b,
-  command: (a: Action<unknown>, b: number) => Nil(),
-  view: (e: Smitten, m: number, s: Date) => {
-    return ['Hello']
-  }
-})
+ComponentNext.from(
+  {
+    init: (a: string, b: number) => 10,
+    update: (a: Action<unknown>, b: number) => b,
+    command: (a: Action<unknown>, b: number) => Nil(),
+    view: (e: Smitten, m: number, s: Date) => {
+      return ['Hello']
+    }
+  },
+  ['hello', 10]
+)
 
 // $ExpectType ComponentNext<{ iState: undefined; oState: undefined; oView: void; }>
 ComponentNext.empty


### PR DESCRIPTION
affects: @action-land/component

`ComponentNext.from` takes component as object rather than `init`, `update`, `command` and `view` separately. 