### PR TITLE
feat(component): from operator takes initparams as spread operator

### DIFF
--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -297,7 +297,7 @@ export class ComponentNext<P1 extends ComponentProps> {
       command: (a: any, s: any) => any
       view: (e: any, s: any, p: P) => V
     },
-    initParams: I
+    ...initParams: I
   ): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
     return new ComponentNext(
       () => component.init(...initParams),

--- a/test/component/componentNext.ts
+++ b/test/component/componentNext.ts
@@ -304,7 +304,8 @@ describe('ComponentNext', () => {
           return ['Hello']
         }
       },
-      ['hello', 10]
+      'hello',
+      10
     )
     it('should call init of old version of component', () => {
       const actual = component._init()

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -146,7 +146,8 @@ ComponentNext.from(
       return ['Hello']
     }
   },
-  ['hello', 10]
+  'hello',
+  10
 )
 
 // $ExpectType ComponentNext<{ iState: undefined; oState: undefined; oView: void; }>


### PR DESCRIPTION
affects: @action-land/component
`ComponentNext.from` operator takes `initParams` as spread operator