### PR TITLE
fix(component): matchC and matchR: fix typings for repeated types

### DIFF
--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -97,7 +97,12 @@ export class ComponentNext<P1 extends ComponentProps> {
     P1,
     {
       iActions: T extends LActionTypes<iActions<P1>>
-        ? Action<V & LActionValues<iActions<P1>>, T>
+        ?
+            | Action<V & LActionValueForType<iActions<P1>, T>, T>
+            | Exclude<
+                iActions<P1>,
+                Action<LActionValueForType<iActions<P1>, T>>
+              >
         : Action<V, T> | iActions<P1>
       oState: oState2 | oState<P1>
     }
@@ -125,7 +130,12 @@ export class ComponentNext<P1 extends ComponentProps> {
     P1,
     {
       iActions: T extends LActionTypes<iActions<P1>>
-        ? Action<V & LActionValues<iActions<P1>>, T>
+        ?
+            | Action<V & LActionValueForType<iActions<P1>, T>, T>
+            | Exclude<
+                iActions<P1>,
+                Action<LActionValueForType<iActions<P1>, T>>
+              >
         : Action<V, T> | iActions<P1>
       oActions: oActions<P1> | Action<V2, T2>
     }

--- a/typings/type.ts
+++ b/typings/type.ts
@@ -32,6 +32,14 @@ $(
     .matchR('inc', (e: {b: number}, s) => s)
 ).iActions
 
+// $ExpectType Action<{ b: number; }, "dec"> | Action<{ b: number; } & { a: string; }, "inc">
+$(
+  ComponentNext.lift({count: 0})
+    .matchR('dec', (e: {b: number}, s) => s)
+    .matchR('inc', (e: {a: string}, s) => s)
+    .matchR('inc', (e: {b: number}, s) => s)
+).iActions
+
 // $ExpectType Action<{ url: string; }, "HTTP"> | Action<{ data: string; }, "Write">
 $(
   ComponentNext.lift({count: 0})
@@ -44,6 +52,14 @@ $(
   ComponentNext.lift({count: 0})
     .matchC('inc', (a: {a: string}, s) => Nil())
     .matchC('inc', (a: {b: number}, s) => Nil())
+).iActions
+
+// $ExpectType Action<{ b: number; }, "dec"> | Action<{ b: number; } & { a: string; }, "inc">
+$(
+  ComponentNext.lift({count: 0})
+    .matchC('dec', (e: {b: number}, s) => Nil())
+    .matchC('inc', (e: {a: string}, s) => Nil())
+    .matchC('inc', (e: {b: number}, s) => Nil())
 ).iActions
 
 // $ExpectType { node: never; children: { child1: never; child2: never; }; }


### PR DESCRIPTION
affects: @action-land/component