### PR TITLE
feat(action): create a fold static method

### DIFF
--- a/test/core/action.ts
+++ b/test/core/action.ts
@@ -27,48 +27,57 @@ describe('action', () => {
 
   describe('fold', () => {
     it('should fold over non-nested actions', () => {
-      const actual = action('A', 50).fold(100, (s, a) => s + a.value)
+      const actual = Action.fold(100, action('A', 50), (s, a) => s + a.value)
       const expected = 150
 
       assert.strictEqual(actual, expected)
     })
 
     it('should fold over nested actions', () => {
-      const actual = action('A', 50)
-        .lift('B')
-        .fold(100, (s, a) => s + a.value.value)
+      const actual = Action.fold(
+        100,
+        action('A', 50).lift('B'),
+        (s, a) => s + a.value.value
+      )
       const expected = 150
 
       assert.strictEqual(actual, expected)
     })
 
     it('should fold over any level of nested actions', () => {
-      const actual = action('A', 50)
-        .lift('B')
-        .lift('C')
-        .lift('D')
-        .fold(100, (s, a) => s + a.value.value.value.value)
+      const actual = Action.fold(
+        100,
+        action('A', 50)
+          .lift('B')
+          .lift('C')
+          .lift('D'),
+        (s, a) => s + a.value.value.value.value
+      )
       const expected = 150
 
       assert.strictEqual(actual, expected)
     })
 
     it('should fold using a nested spec', () => {
-      const actual = action('A', 50)
-        .lift('B')
-        .lift('C')
-        .lift('D')
-        .lift('E')
-        .lift('F')
-        .fold(100, {E: {D: {C: {B: {A: (s, a) => s + a.value}}}}})
-      const expected = 150
+      const actual = Action.fold(
+        {count: 100},
+        action('A', 50)
+          .lift('B')
+          .lift('C')
+          .lift('D')
+          .lift('E')
+          .lift('F'),
 
-      assert.strictEqual(actual, expected)
+        {F: {E: {D: {C: {B: {A: (s, a) => ({count: s.count + a})}}}}}}
+      )
+      const expected = {count: 150}
+
+      assert.deepEqual(actual, expected)
     })
 
     it('should fold nil', () => {
-      const actual = Action.nil().fold(10, (s, a) => s + 1)
-      const expected = 11
+      const actual = Action.fold(100, Action.nil(), (s, a) => s + 1)
+      const expected = 101
 
       assert.strictEqual(actual, expected)
     })

--- a/typings/action.type.ts
+++ b/typings/action.type.ts
@@ -1,9 +1,9 @@
-import {action, Action} from '@action-land/core'
+import {Action} from '@action-land/core'
 
 declare function $<F, B>(a: <S>(s: S, f: F) => B): {spec: F; ret: B}
 declare function ID<T>(): T
 
-// Action.grab should handle Action.nil()
+// Action.fold should handle Action.nil()
 Action.fold(0, Action.nil(), (s, a) => {
   // $ExpectType Nil
   a
@@ -13,7 +13,7 @@ Action.fold(0, Action.nil(), (s, a) => {
   return s
 })
 
-// Action.grab should handle lifted nils
+// Action.fold should handle lifted nils
 Action.fold(0, Action.nil().lift('T'), (s, a) => {
   // $ExpectType Action<Action<never, never>, "T">
   a
@@ -23,7 +23,7 @@ Action.fold(0, Action.nil().lift('T'), (s, a) => {
   return s
 })
 
-// Action.grab should handle lifted nils
+// Action.fold should handle lifted nils
 Action.fold(0, Action.nil().lift('T'), {
   T: (s, a) => {
     // $ExpectType Action<never, never>
@@ -36,7 +36,7 @@ Action.fold(0, Action.nil().lift('T'), {
   }
 })
 
-// Action.grab should handle union of actions
+// Action.fold should handle union of actions
 Action.fold({count: 10}, ID<Action<1, 'B1'> | Action<2, 'B2'>>(), {
   B1: (s, a) => {
     // $ExpectType 1
@@ -49,7 +49,7 @@ Action.fold({count: 10}, ID<Action<1, 'B1'> | Action<2, 'B2'>>(), {
   }
 })
 
-// Action.grab should lifted handle union of actions
+// Action.fold should lifted handle union of actions
 Action.fold({count: 10}, ID<Action<Action<1, 'B1'> | Action<2, 'B2'>, 'A'>>(), {
   A: (s, a) => {
     // $ExpectType Action<1, "B1"> | Action<2, "B2">
@@ -62,7 +62,7 @@ Action.fold({count: 10}, ID<Action<Action<1, 'B1'> | Action<2, 'B2'>, 'A'>>(), {
   }
 })
 
-// Action.grab should lifted handle union of actions thru a nested spec
+// Action.fold should lifted handle union of actions thru a nested spec
 Action.fold({count: 10}, ID<Action<Action<1, 'B1'> | Action<2, 'B2'>, 'A'>>(), {
   A: {
     B1: (s, a) => {

--- a/typings/action.type.ts
+++ b/typings/action.type.ts
@@ -3,18 +3,76 @@ import {action, Action} from '@action-land/core'
 declare function $<F, B>(a: <S>(s: S, f: F) => B): {spec: F; ret: B}
 declare function ID<T>(): T
 
-// action.fold should safely handle Nil
-// $ExpectType (seed: unknown, value: Action<never, never>) => unknown
-$(Action.nil().fold).spec
+// Action.grab should handle Action.nil()
+Action.fold(0, Action.nil(), (s, a) => {
+  // $ExpectType Nil
+  a
 
-// action.fold should safely handle non-nested actions
-// $ExpectType (seed: unknown, value: Action<number, "A">) => unknown
-$(action('A', 100).fold).spec
+  // $ExpectType number
+  s
+  return s
+})
 
-// action.fold should safely handle nested actions
-// $ExpectType FoldSpec<Action<string, "A">, "B", unknown>
-$(action('A', 'A').lift('B').fold).spec
+// Action.grab should handle lifted nils
+Action.fold(0, Action.nil().lift('T'), (s, a) => {
+  // $ExpectType Action<Action<never, never>, "T">
+  a
 
-// action.fold should handle union of actions
-// $ExpectType FoldSpec<Action<1, "B1"> | Action<2, "B2">, "A", unknown>
-$(ID<Action<Action<1, 'B1'> | Action<2, 'B2'>, 'A'>>().fold).spec
+  // $ExpectType number
+  s
+  return s
+})
+
+// Action.grab should handle lifted nils
+Action.fold(0, Action.nil().lift('T'), {
+  T: (s, a) => {
+    // $ExpectType Action<never, never>
+    a
+
+    // FIXME: type should be number and not 0
+    // $ExpectType 0
+    s
+    return s
+  }
+})
+
+// Action.grab should handle union of actions
+Action.fold({count: 10}, ID<Action<1, 'B1'> | Action<2, 'B2'>>(), {
+  B1: (s, a) => {
+    // $ExpectType 1
+    a
+
+    // $ExpectType { count: number; }
+    s
+
+    return {count: s.count + a}
+  }
+})
+
+// Action.grab should lifted handle union of actions
+Action.fold({count: 10}, ID<Action<Action<1, 'B1'> | Action<2, 'B2'>, 'A'>>(), {
+  A: (s, a) => {
+    // $ExpectType Action<1, "B1"> | Action<2, "B2">
+    a
+
+    // $ExpectType { count: number; }
+    s
+
+    return {count: s.count + a.value}
+  }
+})
+
+// Action.grab should lifted handle union of actions thru a nested spec
+Action.fold({count: 10}, ID<Action<Action<1, 'B1'> | Action<2, 'B2'>, 'A'>>(), {
+  A: {
+    B1: (s, a) => {
+      // $ExpectType 1
+      a
+
+      // $ExpectType { count: number; }
+      s
+
+      return {count: s.count + a}
+    }
+  }
+})


### PR DESCRIPTION
affects: @action-land/core

Action.fold() static can gaurantee better type-safety expecially around unions.

BREAKING CHANGE:
removing the \`fold()\` method and adding \`Action.fold()\` static method