### PR TITLE
fix(component): set 'State' of Component a iState of ComponentNext

### DIFF
--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -380,7 +380,7 @@ export class ComponentNext<P1 extends ComponentProps> {
     )
   }
 
-  get component(): Component<oState<P1>, iProps<P1>, [], oView<P1>> {
+  get component(): Component<iState<P1>, iProps<P1>, [], oView<P1>> {
     return {
       init: this._init,
       update: this._update,

--- a/typings/component.type.ts
+++ b/typings/component.type.ts
@@ -214,3 +214,6 @@ ComponentNext.lift({color: 'red'})
 
     return true
   })
+
+// $ExpectType () => { a: boolean; }
+ComponentNext.lift({a: true}).component.init


### PR DESCRIPTION
Currently it's set to oState, which is erroneous if the component doesn't have reducers

affects: @action-land/component

