### PR TITLE
feat(component): add iaction type in componentNext from

### DIFF
--- a/modules/component/src/componentNext.ts
+++ b/modules/component/src/componentNext.ts
@@ -1,4 +1,5 @@
 import {Action, action, isAction, List, Nil} from '@action-land/core'
+import {AType} from '@action-land/core/src/action'
 import {LinkedList} from '../internals/linkedList'
 import {Component} from './component'
 
@@ -360,7 +361,13 @@ export class ComponentNext<P1 extends ComponentProps> {
     )
   }
 
-  static from<A, V, P, I extends unknown[]>(
+  static from<
+    A,
+    V,
+    P,
+    I extends unknown[],
+    IA extends Action<unknown, AType> = Action<unknown, AType>
+  >(
     component: {
       init: (...t: I) => A
       update: (a: any, s: any) => any
@@ -368,7 +375,7 @@ export class ComponentNext<P1 extends ComponentProps> {
       view: (e: any, s: any, p: P) => V
     },
     ...initParams: I
-  ): ComponentNext<{iState: A; oState: A; oView: V; iProps: P}> {
+  ): ComponentNext<{iState: A; oState: A; oView: V; iProps: P; iActions: IA}> {
     return new ComponentNext(
       () => component.init(...initParams),
       component.update,

--- a/typings/component.type.ts
+++ b/typings/component.type.ts
@@ -160,7 +160,7 @@ $(
 // $ExpectType { color: string; count: number; }
 $(ComponentNext.lift({count: 10}).configure(s => ({...s, color: 'red'}))).iState
 
-// $ExpectType ComponentNext<{ iState: number; oState: number; oView: string[]; iProps: Date; }>
+// $ExpectType ComponentNext<{ iState: number; oState: number; oView: string[]; iProps: Date; iActions: Action<unknown, string | number>; }>
 ComponentNext.from(
   {
     init: (a: string, b: number) => 10,
@@ -173,6 +173,29 @@ ComponentNext.from(
   'hello',
   10
 )
+
+ComponentNext.from<
+  number,
+  string[],
+  Date,
+  [string, number],
+  Action<string, 't1'> | Action<string, 't2'>
+>(
+  {
+    init: (a: string, b: number) => 10,
+    update: (a: Action<unknown>, b: number) => b,
+    command: (a: Action<unknown>, b: number) => Nil(),
+    view: (e: Smitten, m: number, s: Date) => {
+      return ['Hello']
+    }
+  },
+  'hello',
+  10
+).render(_ => {
+  // Should be able to get actions in render function
+  // $ExpectType { t1: (e: string) => unknown; t2: (e: string) => unknown; }
+  _.actions
+})
 
 // $ExpectType ComponentNext<{ iState: undefined; oView: void; }>
 ComponentNext.empty


### PR DESCRIPTION
affects: @action-land/component

**Why is this required?**
Right now when we lift the component to componentNext and write a render
function over it, there is no way to fire actions handled by old component, this provides a way to
fire those actions