### PR TITLE
feat(listHOC): set state via Option [DWP-202]

### DIFF
--- a/modules/component/src/listComponentState.ts
+++ b/modules/component/src/listComponentState.ts
@@ -13,12 +13,19 @@ export class ListComponentState<S> {
     return new ListComponentState(baseInit, List.empty(), HashMap.of())
   }
 
-  set(k: ListKey, value: S = this.baseInit()): ListComponentState<S> {
+  set(
+    k: ListKey,
+    value: S | Option<S> = this.baseInit()
+  ): ListComponentState<S> {
     const items = this.hashMap.has(k) ? this.keys : this.keys.prepend(k)
+
     return new ListComponentState(
       this.baseInit,
       items,
-      this.hashMap.set(k, value)
+      this.hashMap.set(
+        k,
+        value instanceof Option ? value.getOrElse(this.baseInit()) : value
+      )
     )
   }
 

--- a/test/component/listComponentState.ts
+++ b/test/component/listComponentState.ts
@@ -104,5 +104,23 @@ describe('listComponentState', () => {
       const expected = [1]
       assert.deepEqual(actual, expected)
     })
+    it('should accept an `Option` as input', () => {
+      const state = ListComponentState.of(() => ({
+        count: 10
+      }))
+      const updatedState = state.set('k', Option.some({count: 20}))
+      const actual = updatedState.get('k').getOrElse({count: 10})
+      const expected = {count: 20}
+      assert.deepEqual(actual, expected)
+    })
+    it('should accept an `Option.none` as input', () => {
+      const state = ListComponentState.of(() => ({
+        count: 10
+      }))
+      const updatedState = state.set('k', Option.none())
+      const actual = updatedState.get('k').getOrElse({count: 5})
+      const expected = {count: 10}
+      assert.deepEqual(actual, expected)
+    })
   })
 })


### PR DESCRIPTION
## Problem

- When working on the state of a child, one needs to do a `get`, then a `getOrElse` and then set.
- this looks super ugly when dealing with complex steps
  - https://dream11.atlassian.net/browse/DWP-202

## Proposed Solution

- Ideally I'd like to just `get`, `map` and then `set`.